### PR TITLE
implement serde as a feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
   - nightly
 
 script:
-  - cargo build --features="derive" || travis_terminate 1
-  - cargo test --features="derive" || travis_terminate 1
-  - cargo doc --features="derive" || travis_terminate 1
+  - cargo build --features="derive serde" || travis_terminate 1
+  - cargo test --features="derive serde" || travis_terminate 1
+  - cargo doc --features="derive serde" || travis_terminate 1
 
 env:
   - RUSTFLAGS="--deny warnings"
@@ -21,6 +21,6 @@ matrix:
       language: rust
       rust: nightly
       script:
-        - cargo build --features="derive nightly" || travis_terminate 1
-        - cargo test --features="derive nightly" || travis_terminate 1
-        - cargo doc --features="derive nightly" || travis_terminate 1
+        - cargo build --features="derive serde nightly" || travis_terminate 1
+        - cargo test --features="derive serde nightly" || travis_terminate 1
+        - cargo doc --features="derive serde nightly" || travis_terminate 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ nightly = []
 
 [dependencies]
 atomig-macro = { version = "0.1.0", path = "atomig-macro", optional = true }
+serde = {version = "1", default-features = false, optional = true}
+
+[dev-dependencies]
+bincode = {version = "1"}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ nightly = []
 
 [dependencies]
 atomig-macro = { version = "0.1.0", path = "atomig-macro", optional = true }
-serde = {version = "1", default-features = false, optional = true}
+serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
-bincode = {version = "1"}
+bincode = { version = "1" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Atomig: generic and convenient `std` atomics
 Offers `Atomic<T>` that can be used with primitive and custom types.
 *However*, it only works with types that can actually use atomic operations: a lock-based fallback for other types is not used!
 This crate is based on `std`'s atomics and therefore does not contain any `unsafe` code!
-This crate also does not have any dependencies by default.
+This crate also does not have any dependencies by default. If you enable the `serde` trait, then
+this crate will depend on "serde" and `Serialize` / `Deserialize` will be implemented for `Atomic<T>` when
+appropriate, using sequentially-consistent ordering.
 
 Simple example with primitive types:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Atomig: generic and convenient `std` atomics
 Offers `Atomic<T>` that can be used with primitive and custom types.
 *However*, it only works with types that can actually use atomic operations: a lock-based fallback for other types is not used!
 This crate is based on `std`'s atomics and therefore does not contain any `unsafe` code!
-This crate also does not have any dependencies by default. If you enable the `serde` trait, then
-this crate will depend on "serde" and `Serialize` / `Deserialize` will be implemented for `Atomic<T>` when
-appropriate, using sequentially-consistent ordering.
+This crate also does not have any dependencies by default.
+If you enable the `serde` feature, then this crate will depend on `serde` and `Serialize` / `Deserialize` will be
+implemented for `Atomic<T>` when appropriate, using sequentially-consistent ordering.
 
 Simple example with primitive types:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,17 +849,18 @@ impl<T: Atom> From<T> for Atomic<T> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<T: Atom + serde::Serialize> serde::Serialize for Atomic<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer,
+    where
+        S: serde::Serializer,
     {
         self.load(Ordering::SeqCst).serialize(serializer)
     }
 }
 
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Atom + serde::Deserialize<'de>> serde::Deserialize<'de> for Atomic<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,12 @@
 //!
 //! # Cargo features
 //!
-//! This crate has two Cargo features which are disabled by default:
+//! This crate has three Cargo features which are disabled by default:
 //! - **`derive`**: enables the custom derives for [`Atom`], [`AtomLogic`] and
 //!   [`AtomInteger`]. It is disabled by default because it requires compiling
 //!   a few dependencies for procedural macros.
+//! - **`serde`**: enables the serde [`Serialize`] and [`Deserialize`] traits
+//!   on `Atomic<T>` if `T` is serializable or deserializable.
 //! - **`nightly`**: only usable with a nightly compiler. Does two things:
 //!     - Adds unstable methods to this API, specifically `fetch_update`,
 //!       `fetch_max` and `fetch_min`.
@@ -844,6 +846,26 @@ impl<T: Atom + Default> Default for Atomic<T> {
 impl<T: Atom> From<T> for Atomic<T> {
     fn from(v: T) -> Self {
         Self::new(v)
+    }
+}
+
+#[cfg(feature="serde")]
+impl<T: Atom + serde::Serialize> serde::Serialize for Atomic<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer,
+    {
+        self.load(Ordering::SeqCst).serialize(serializer)
+    }
+}
+
+
+#[cfg(feature="serde")]
+impl<'de, T: Atom + serde::Deserialize<'de>> serde::Deserialize<'de> for Atomic<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::Deserialize::deserialize(deserializer).map(Self::new)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,8 +3,10 @@ use super::Atom;
 macro_rules! gen_tests {
     (
         $mod_name:ident, $ty:ty, $val0:expr, $val1:expr,
-        $with_logic:ident, $with_int:ident, $with_default:ident,
-        $with_serde:ident
+        [
+            $with_logic:ident $with_int:ident
+            $with_default:ident $with_serde:ident
+        ]
     ) => {
         mod $mod_name {
             use crate::{Atomic, Ordering};
@@ -60,7 +62,7 @@ macro_rules! gen_tests {
             }
         }
     };
-    (@logic $val0:expr, $val1:expr, true) => {
+    (@logic $val0:expr, $val1:expr, y) => {
         #[test]
         fn logic() {
             let a = Atomic::new($val0);
@@ -80,9 +82,9 @@ macro_rules! gen_tests {
             assert_eq!(a.load(Ordering::SeqCst), $val0 ^ $val1);
         }
     };
-    (@logic $val0:expr, $val1:expr, false) => {};
+    (@logic $val0:expr, $val1:expr, n) => {};
 
-    (@integer $val0:expr, $val1:expr, true) => {
+    (@integer $val0:expr, $val1:expr, y) => {
         #[test]
         fn integer() {
             let a = Atomic::new($val0);
@@ -94,22 +96,22 @@ macro_rules! gen_tests {
             assert_eq!(a.load(Ordering::SeqCst), $val0.wrapping_sub($val1));
         }
     };
-    (@integer $val0:expr, $val1:expr, false) => {};
+    (@integer $val0:expr, $val1:expr, n) => {};
 
-    (@default $ty:ty, true) => {
+    (@default $ty:ty, y) => {
         #[test]
         fn default() {
             let a: Atomic<$ty> = Default::default();
             assert_eq!(a.load(Ordering::SeqCst), <$ty>::default());
         }
     };
-    (@default $ty:ty, false) => {};
+    (@default $ty:ty, n) => {};
 
-    (@serde $val0:expr, $ty:ty, true) => {
-        #[cfg(feature="serde")]
+    (@serde $val0:expr, $ty:ty, y) => {
+        #[cfg(feature = "serde")]
         use bincode;
 
-        #[cfg(feature="serde")]
+        #[cfg(feature = "serde")]
         #[test]
         fn test_serde_round_trip() {
             let src = Atomic::new($val0);
@@ -119,26 +121,26 @@ macro_rules! gen_tests {
         }
     };
 
-    (@serde $val0:expr, $ty:ty, false) => {};
+    (@serde $val0:expr, $ty:ty, n) => {};
 }
 
-//         mod     ty     val0    val1     logic  int    dflt  serde
-gen_tests!(_bool,  bool,  true,   false,   true,  false, true, true);
-gen_tests!(_u8,    u8,    7u8,    33u8,    true,  true,  true, true);
-gen_tests!(_i8,    i8,    7i8,    33i8,    true,  true,  true, true);
-gen_tests!(_u16,   u16,   7u16,   33u16,   true,  true,  true, true);
-gen_tests!(_i16,   i16,   7i16,   33i16,   true,  true,  true, true);
-gen_tests!(_u32,   u32,   7u32,   33u32,   true,  true,  true, true);
-gen_tests!(_i32,   i32,   7i32,   33i32,   true,  true,  true, true);
-gen_tests!(_u64,   u64,   7u64,   33u64,   true,  true,  true, true);
-gen_tests!(_i64,   i64,   7i64,   33i64,   true,  true,  true, true);
-gen_tests!(_usize, usize, 7usize, 33usize, true,  true,  true, true);
-gen_tests!(_isize, isize, 7isize, 33isize, true,  true,  true, true);
-gen_tests!(_f32,   f32,   7.0f32, 33.0f32, false, false, true, true);
-gen_tests!(_f64,   f64,   7.0f64, 33.0f64, false, false, true, true);
-gen_tests!(_char,  char,  'x',    '♥',     false, false, true, true);
-gen_tests!(_ptr, *mut String, 0 as *mut String, 0xBADC0DE as *mut String, false, false, false, false);
-gen_tests!(custom, super::Foo, super::Foo::Nothing, super::Foo::Set(0b101), false, false, true, false);
+//         mod     ty     val0    val1     [logic int default serde]
+gen_tests!(_bool,  bool,  true,   false,   [y n y y]);
+gen_tests!(_u8,    u8,    7u8,    33u8,    [y y y y]);
+gen_tests!(_i8,    i8,    7i8,    33i8,    [y y y y]);
+gen_tests!(_u16,   u16,   7u16,   33u16,   [y y y y]);
+gen_tests!(_i16,   i16,   7i16,   33i16,   [y y y y]);
+gen_tests!(_u32,   u32,   7u32,   33u32,   [y y y y]);
+gen_tests!(_i32,   i32,   7i32,   33i32,   [y y y y]);
+gen_tests!(_u64,   u64,   7u64,   33u64,   [y y y y]);
+gen_tests!(_i64,   i64,   7i64,   33i64,   [y y y y]);
+gen_tests!(_usize, usize, 7usize, 33usize, [y y y y]);
+gen_tests!(_isize, isize, 7isize, 33isize, [y y y y]);
+gen_tests!(_f32,   f32,   7.0f32, 33.0f32, [n n y y]);
+gen_tests!(_f64,   f64,   7.0f64, 33.0f64, [n n y y]);
+gen_tests!(_char,  char,  'x',    '♥',     [n n y y]);
+gen_tests!(_ptr, *mut String, 0 as *mut String, 0xBADC0DE as *mut String,   [n n n n]);
+gen_tests!(custom, super::Foo, super::Foo::Nothing, super::Foo::Set(0b101), [n n y n]);
 
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
I just implemented this upstream in Serde 1.0.95 and it seems like it would be useful here.

`bincode` is just for round-tripping in the tests as a fairly simple serializer.