### PR TITLE
Add `forbid(unsafe_code)` to the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
 //!     `Atomic<T>` if `T` is serializable or deserializable.
 //!
 
+#![forbid(unsafe_code)]
 #![no_std]
 
 #[cfg(test)]


### PR DESCRIPTION
This crate's wonderful API / idea is that by delegating everything to trait methods, it gives the "illusion" and the ergonomics of a generic API, while it technically (through helper macros) hand-rolls all of the atomic operations, **hence needing no `unsafe` code _whatsoever_**, as stated in the very crate docs. Brilliant!

  - Compare that to many other "generic" `AtomicCell` APIs, which are _unsound_ in presence of, for instance, padding bytes!

Alas, currently one has to "grep" the codebase to make sure "the lack of `unsafe`" property does hold, since there is no `forbid(unsafe_code)` statement at the root of the crate. I think having such an attribute would help make that point way more visible, to even automated code analysis tools (_e.g._, `cargo-geiger`), and, more generally, as a cultural thing (it expresses a future-proofing _intent_) 🙂

  - _c.f._, the [Safety Dance initiative](https://github.com/rust-secure-code/safety-dance/tree/0ee938777035a5dd061ea0c2531b6f7275fd28a8#:~:text=add%20a%20%23!%5Bforbid(unsafe_code)%5D%20attribute%20to%20its%20src/lib.rs%20or%20main.rs.%20After%20doing%20that%2C%20help%20others%20discover%20Safety%20Dance%20by%20adding%20a%20badge%20to%20your%20README.md%3A)