### PR TITLE
Add `fn Atomic::from_impl`, a `const fn` way to create an `Atomic`, but from the underlying atomic impl directly

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,11 +1,7 @@
-//! Traits for abstracting over `std` atomics. Basically implementation detail!
+//! Traits for abstracting over `std` atomics. Mostly hidden implementation detail.
 //!
-//! This module only promises stability about the trait names and which types
-//! these traits are implemented by (though, new impls can be added at any
-//! time, of course). In particular, the traits' methods and other items are
-//! not part of the public API of `atomig`. Those items are also hidden in the
-//! documentation. And the traits are sealed anyway, so you can't implement
-//! them for your own types.
+//! Most items of these traits are hidden and not part of the public API of this library.
+//! You cannot implement these traits yourself.
 
 use core::{num::Wrapping, sync::atomic::{self, Ordering}};
 use super::{Atom, AtomLogic, AtomInteger};
@@ -28,7 +24,6 @@ mod sealed {
 /// the public API -- see the module docs.
 pub trait PrimitiveAtom: Sized + Copy + sealed::Sealed {
     /// The standard library type that is the atomic version of `Self`.
-    #[doc(hidden)]
     type Impl;
 
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,26 @@ impl<T: Atom> Atomic<T> {
         Self(T::Repr::into_impl(v.pack()))
     }
 
+    /// Creates a new atomic value from the underlying `Atomic*` type from `std`.
+    ///
+    /// Since [`Atom`] is a `trait` and `const fn`s in `trait`s are not supported yet,
+    /// the only way for this to be a `const fn` is
+    /// to take the underyling atomic impl type directly.
+    ///
+    /// This allows `static` `Atomic`s to be created.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use atomig::Atomic;
+    /// use std::sync::atomic::AtomicU32;
+    ///
+    /// static X: Atomic<u32> = Atomic::from_impl(AtomicU32::new(7));
+    /// ```
+    pub const fn from_impl(v: <<T as Atom>::Repr as PrimitiveAtom>::Impl) -> Self {
+        Self(v)
+    }
+
     /// Consumes the atomic and returns the contained value.
     ///
     /// This is safe because passing `self` by value guarantees that no other


### PR DESCRIPTION
I'm trying to have a `static` `Atomic<T>`, but I can't initialize it as there's no `const fn` way to create an `Atomic<T>`, since `Atom` is a `trait` and `const fn`s on `trait`s aren't supported yet.  So I added this `const fn` method `from_impl` that takes the underlying atomic impl instead of a `T`, relying on the user to call a concrete `const fn` to get the atomic type from `T`.

As an example, I could do this:

```rust
use atomig::Atom;
use atomig::Atomic;
use bitflags::bitflags;
use std::sync::atomic::AtomicU8;

#[derive(Atom)]
pub struct Flags(u8);

bitflags! {
    impl Flags: u8 {}
}

static FLAGS: Atomic<Flags> = Atomic::from_impl(AtomicU8::new(Flags::empty().bits()));
```

Previously, this `PrimitiveAtom::Impl` associated type was `#[doc(hidden)]`, but now that it is part of the public API through `Atomic::from_impl`, it must be public.