### PR TITLE
feat: add get_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@
 //!     `Atomic<T>` if `T` is serializable or deserializable.
 //!
 
-#![forbid(unsafe_code)]
 #![no_std]
 
 #[cfg(test)]
@@ -432,6 +431,15 @@ impl<T: Atom> Atomic<T> {
     /// ```
     pub fn swap(&self, v: T, order: Ordering) -> T {
         T::unpack(T::Repr::swap(&self.0, v.pack(), order))
+    }
+
+    ///
+    /// Returns a mutable reference to the underlying integer.
+    /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the atomic data.
+    pub fn get_mut(&mut self) -> &mut T {
+        let ptr = core::ptr::addr_of_mut!(self.0);
+        let ptr = ptr as *mut T;
+        unsafe { &mut *ptr }
     }
 
     /// Stores a value into the atomic if the current value is the same as the

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -269,3 +269,12 @@ fn _atomic_is_always_send_sync<T: Atom>(a: Atomic<T>) {
 
     requires_send_sync(a);
 }
+
+#[test]
+fn test_get_mut() {
+    let mut i = Atomic::<i32>::new(0);
+    let x = i.get_mut();
+    *x = 20;
+
+    assert_eq!(i.load(Ordering::Acquire), 20);
+}


### PR DESCRIPTION
I hope that the API of atomig can be aligned with the API in the Rust standard library. However, this will introduce unsafe code. In theory, this will not have actual unsafe behavior.

The main reason for introducing this code is to avoid the cost of atomic operations in some cases, and another reason is to align with the API in the standard library.

If this PR is accepted, I will add more methods